### PR TITLE
update Dockerfile to facilitate caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM satijalab/seurat:3.2.0
+FROM satijalab/seurat:3.2.2
 
 RUN apt-get update
 RUN apt-get install -y libv8-dev
@@ -14,14 +14,23 @@ RUN gcc -O2 -fPIC -shared lzf/*.c lzf_filter.c $(pkg-config --cflags --libs hdf5
 WORKDIR /
 ENV HDF5_PLUGIN_PATH=/lzf
 
-RUN R -e "install.packages('remotes')"
+RUN R --no-echo -e "install.packages('remotes')"
 
 RUN wget https://raw.githubusercontent.com/pshved/timeout/master/timeout && chmod +x timeout
 
 COPY Rprofile.site /usr/lib/R/etc/
-COPY . /root/seurat-mapper
+RUN R --no-echo -e "install.packages(c('DT', 'future', 'ggplot2',  'googlesheets4', 'hdf5r', 'htmltools', 'httr', 'patchwork', 'rlang', 'shiny', 'shinyBS', 'shinydashboard', 'shinyjs', 'stringr', 'withr', 'BiocManager'), repo='https://cloud.r-project.org')"
+RUN R --no-echo -e "remotes::install_github(c('immunogenomics/presto', 'jlmelville/uwot', 'mojaveazure/seurat-disk', 'satijalab/seurat@release/4.0.0'))"
+RUN R --no-echo -e "BiocManager::install('glmGamPoi')"
 
-RUN R -e "remotes::install_local('/root/seurat-mapper')"
+ARG SEURAT_VER=unknown
+RUN echo "$SEURAT_VER"
+RUN R --no-echo -e "remotes::install_github('satijalab/seurat@release/4.0.0')"
+
+ARG AZIMUTH_VER=unknown
+RUN echo "$AZIMUTH_VER"
+COPY . /root/seurat-mapper
+RUN R --no-echo -e "install.packages('/root/seurat-mapper', repos = NULL, type = 'source')"
 
 EXPOSE 3838
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN R --no-echo -e "remotes::install_github('satijalab/seurat@release/4.0.0')"
 
 ARG AZIMUTH_VER=unknown
 RUN echo "$AZIMUTH_VER"
-COPY . /root/seurat-mapper
-RUN R --no-echo -e "install.packages('/root/seurat-mapper', repos = NULL, type = 'source')"
+COPY . /root/azimuth
+RUN R --no-echo -e "install.packages('/root/azimuth', repos = NULL, type = 'source')"
 
 EXPOSE 3838
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ ENV HDF5_PLUGIN_PATH=/lzf
 
 RUN R --no-echo -e "install.packages('remotes')"
 
-RUN wget https://raw.githubusercontent.com/pshved/timeout/master/timeout && chmod +x timeout
-
 COPY Rprofile.site /usr/lib/R/etc/
 RUN R --no-echo -e "install.packages(c('DT', 'future', 'ggplot2',  'googlesheets4', 'hdf5r', 'htmltools', 'httr', 'patchwork', 'rlang', 'shiny', 'shinyBS', 'shinydashboard', 'shinyjs', 'stringr', 'withr', 'BiocManager'), repo='https://cloud.r-project.org')"
 RUN R --no-echo -e "remotes::install_github(c('immunogenomics/presto', 'jlmelville/uwot', 'mojaveazure/seurat-disk', 'satijalab/seurat@release/4.0.0'))"

--- a/README.Rmd
+++ b/README.Rmd
@@ -173,6 +173,10 @@ docker run -it -p 3838:3838 -v /path/to/reference:/reference-data:ro azimuth
 If port 3838 is already in use on the host or you wish to use a different port, use `-p NNNN:3838` in the run command instead, to bind port NNNN on the host to port 3838 on the container.
 The container runs the command `R -e "Azimuth::AzimuthApp(reference = '/reference-data')"` by default.
 
+### Rebuilding the Docker image more quickly in certain cases
+
+The docker image takes about 20 minutes to build from scratch. To save time, adding the argument `--build-arg SEURAT_VER=$(date +%s)` to the `docker build` command will use cached layers of the image (if available) and only reinstall Seurat and Azimuth (and not any of the dependencies), which takes less than a minute. Alternatively, to only reinstall Azimuth (and not Seurat or other dependencies) use the argument `--build-arg AZIMUTH_VER=$(date +%s)`.
+
 ### Specifying options
 
 You can set options by passing a parameter to the `AzimuthApp` function:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ port NNNN on the host to port 3838 on the container. The container runs
 the command `R -e "Azimuth::AzimuthApp(reference = '/reference-data')"`
 by default.
 
+### Rebuilding the Docker image more quickly in certain cases
+
+The docker image takes about 20 minutes to build from scratch. To save
+time, adding the argument `--build-arg SEURAT_VER=$(date +%s)` to the
+`docker build` command will use cached layers of the image (if
+available) and only reinstall Seurat and Azimuth (and not any of the
+dependencies), which takes less than a minute. Alternatively, to only
+reinstall Azimuth (and not Seurat or other dependencies) use the
+argument `--build-arg AZIMUTH_VER=$(date +%s)`.
+
 ### Specifying options
 
 You can set options by passing a parameter to the `AzimuthApp` function:


### PR DESCRIPTION
Small updates to the Dockerfile to enable caching when only updating azimuth code.

* Adds lines to install CRAN, github, and bioconductor dependencies separately
* Adds two build ARGS to enable selective rebuilding
  * `SEURAT_VER` - reinstall latest `release/4.0.0` version of Seurat (also updates Azimuth code)
  * `AZIMUTH_VER` - reinstall with latest changes to local Azimuth code
  * to enable, just pass anything to the build ARGS. Passing the time seems to work well and will always guarantee a rebuild ( `docker build --build-arg SEURAT_VER=$(date +%s) -t azimuth .`)