### PR TITLE
Update template.R

### DIFF
--- a/inst/resources/template.R
+++ b/inst/resources/template.R
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 # Ensure Seurat v4.0 or higher is installed
-if (packageVersion(pkg = "Seurat") < package_version(x = "3.9.9002")) {
+if (packageVersion(pkg = "Seurat") < package_version(x = "3.9.9.9002")) {
   stop("Mapping datasets requires Seurat v4 or higher", call. = FALSE)
 }
 


### PR DESCRIPTION
It seems that this condition should be comparing to `3.9.9.9002` rather than `3.9.9002` since the Seurat version on the `release/4.0.0` branch has version `3.9.9.9023` https://github.com/satijalab/seurat/blob/release/4.0.0/DESCRIPTION#L2