### PR TITLE
Restructure the feature plots tab selection boxes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Azimuth
 Type: Package
 Title: A Shiny App Demonstrating a Query-Reference Mapping Algorithm for Single-Cell Data
-Version: 0.2.0.9007
-Date: 2021-02-11
+Version: 0.2.0.9008
+Date: 2021-02-12
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
   person(given = "Charlotte", family = "Darby", email = "cdarby@nygenome.org", role = "aut", comment = c(ORCID = "0000-0003-2195-5300")),

--- a/R/ui.R
+++ b/R/ui.R
@@ -248,6 +248,7 @@ AzimuthUI <- tagList(
         ),
         # Feature tab
         tabItem(
+          tags$head(tags$style(HTML(".selectize-dropdown .optgroup-header { font-weight: bold; font-size: 13px; color: black; background: #f6f6f6}"))),
           tabName = 'tab_feature',
           box(
             title = 'Feature Plots',
@@ -274,25 +275,7 @@ AzimuthUI <- tagList(
               class = 'thirds',
               selectizeInput(
                 inputId = 'metadata.cont',
-                label = 'Continuous Metadata',
-                choices = ''
-              )
-            ),
-            div(
-              id = 'scoregroupinput',
-              class = 'thirds',
-              selectizeInput(
-                inputId = 'scoregroup',
-                label = 'Predicted Metadata',
-                choices = ''
-              )
-            ),
-            div(
-              id = 'scorefeatureinput',
-              class = 'thirds',
-              selectizeInput(
-                inputId = 'scorefeature',
-                label = 'Prediction Score',
+                label = 'Prediction Scores and Metadata',
                 choices = ''
               )
             ),


### PR DESCRIPTION
This PR restructures the UI for the selection boxes on the "Feature Plots" tab. This combines the prediction scores and metadata into a single dropdown, with grouping headers (e.g. Max prediction scores, Prediction scores L1, Other metadata ). Also, updates the titles of the associated FeaturePlot/VlnPlot to match.