### PR TITLE
improve error checking, min cells visibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Azimuth
 Type: Package
 Title: A Shiny App Demonstrating a Query-Reference Mapping Algorithm for Single-Cell Data
-Version: 0.2.0.9016
+Version: 0.2.0.9017
 Date: 2021-02-16
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/R/server.R
+++ b/R/server.R
@@ -443,7 +443,10 @@ AzimuthServer <- function(input, output, session) {
           output$valuebox.upload <- renderValueBox(expr = {
             valueBox(
               value = ncellsupload,
-              subtitle = 'cells uploaded',
+              subtitle = paste0(
+                'cells uploaded - ',
+                 getOption(x = 'Azimuth.map.ncells'), ' required'
+              ),
               icon = icon(name = 'times'),
               color = 'red'
             )
@@ -533,7 +536,10 @@ AzimuthServer <- function(input, output, session) {
       if (ncellspreproc < getOption(x = "Azimuth.map.ncells")) {
         output$valuebox.preproc <- renderValueBox(expr = valueBox(
           value = ncellspreproc,
-          subtitle = "cells after filtering",
+          subtitle = paste0(
+            'cells after filtering - ',
+            getOption(x = 'Azimuth.map.ncells'), ' required'
+          ),
           icon = icon("times"),
           color = "red"
         ))
@@ -638,7 +644,11 @@ AzimuthServer <- function(input, output, session) {
             )
           ))
         }
-        if (nanchors < getOption(x = 'Azimuth.map.nanchors')) {
+        if (nanchors < getOption(x = 'Azimuth.map.nanchors') |
+            length(x = unique(x = slot(
+              object = app.env$anchors, name = "anchors")[, 2]
+            )) < 50
+        ) {
           output$valuebox.mapped <- renderValueBox(expr = {
             valueBox(
               value = 'Failure',


### PR DESCRIPTION
If fewer than `Azimuth.map.ncells` uploaded/filtered, display the required minimum in the error box. Also prevent crashing if fewer than 50 unique query cells form anchors. 