### PR TITLE
Reimplement sorting in FilterFeatures

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1181,10 +1181,12 @@ AzimuthServer <- function(input, output, session) {
           yes = getOption(x = 'Azimuth.app.default_gene'),
           no = VariableFeatures(object = app.env$object)[1]
         )
-        show.features <- sort(VariableFeatures(app.env$object)[1:selectize.opts$maxOptions])
-        app.env$features <- FilterFeatures(
-          features = c(show.features, setdiff(rownames(x = app.env$object), show.features))
-        )
+        app.env$features <- unique(x = c(
+          FilterFeatures(
+            features = VariableFeatures(object = app.env$object)[1:selectize.opts$maxOptions]
+          ),
+          FilterFeatures(features = rownames(x = app.env$object))
+        ))
         updateSelectizeInput(
           session = session,
           inputId = 'feature',

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -279,12 +279,12 @@ CategoryTable <- function(
 #' @seealso \code{\link[shiny]{selectInput}}
 #'
 FilterFeatures <- function(features) {
-  return(grep(
+  return(sort(x = grep(
     pattern = '\\.\\d+$',
     x = features,
     value = TRUE,
     invert = TRUE
-  ))
+  )))
 }
 
 #' Format Time Differences


### PR DESCRIPTION
Ensures that all features are sorted properly. Also 
 - Applies `FilterFeatures` to variable features
 - Replaces the `setdiff` with a `unique` to avoid extra holding variables