### PR TITLE
eliminate errors when inputting another query

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Azimuth
 Type: Package
 Title: A Shiny App Demonstrating a Query-Reference Mapping Algorithm for Single-Cell Data
-Version: 0.2.0.9019
-Date: 2021-02-16
+Version: 0.2.0.9020
+Date: 2021-02-17
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
   person(given = "Charlotte", family = "Darby", email = "cdarby@nygenome.org", role = "aut", comment = c(ORCID = "0000-0003-2195-5300")),

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM satijalab/seurat:4.0.0
 RUN apt-get update
 RUN apt-get install -y libv8-dev
 
-RUN mkdir lzf 
+RUN mkdir lzf
 WORKDIR /lzf
-RUN wget https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf_filter.c https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf_filter.h 
-RUN mkdir lzf 
+RUN wget https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf_filter.c https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf_filter.h
+RUN mkdir lzf
 WORKDIR /lzf/lzf
 RUN wget https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf/lzf_c.c https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf/lzf_d.c https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf/lzfP.h https://raw.githubusercontent.com/h5py/h5py/3.0.0/lzf/lzf/lzf.h
 WORKDIR /lzf

--- a/R/server.R
+++ b/R/server.R
@@ -106,9 +106,9 @@ AzimuthServer <- function(input, output, session) {
     addClass(id = 'biotable', class = 'fulls')
   }
   ResetEnv <- function() {
+    output$menu2 <- NULL
     react.env$plot.qc <- FALSE
     app.env$messages <- NULL
-    app.env$object <- NULL
     output$valubox.upload <- NULL
     output$valuebox.preproc <- NULL
     output$valuebox.mapped <- NULL
@@ -239,7 +239,6 @@ AzimuthServer <- function(input, output, session) {
     eventExpr = react.env$path,
     handlerExpr = {
       if (!is.null(x = react.env$path) && nchar(x = react.env$path)) {
-        ResetEnv()
         withProgress(
           message = 'Reading Input',
           expr = {


### PR DESCRIPTION
-hides menu2 (mapping tabs) when another dataset is uploaded 
-keeps `app.env$object` rather than setting to NULL -- so while new UI renders, it temporarily shows previous plot rather than an error
-gets rid of redundant call to ResetEnv

(can't seem to retain the Dockerfile spaces)