### PR TITLE
Improve filtering of query data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: Azimuth
 Type: Package
 Title: A Shiny App Demonstrating a Query-Reference Mapping Algorithm for Single-Cell Data
-Version: 0.3.0
-Date: 2021-02-17
+Version: 0.3.1
+Date: 2021-03-12
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),
   person(given = "Charlotte", family = "Darby", email = "cdarby@nygenome.org", role = "aut", comment = c(ORCID = "0000-0003-2195-5300")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# Azimuth 0.3.1 (2021-03-12)
+
+## Changes
+- Loading query datasets now filters out cells with zero counts and features with zero counts.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -74,22 +74,23 @@ LoadFileInput <- function(path) {
       if (is.list(x = mat)) {
         mat <- mat[[1]]
       }
-      CreateSeuratObject(counts = mat)
+      CreateSeuratObject(counts = mat, min.cells = 1, min.features = 1)
     },
     'rds' = {
       object <- readRDS(file = path)
       if (inherits(x = object, what = c('Matrix', 'matrix', 'data.frame'))) {
-        object <- CreateSeuratObject(counts = as.sparse(x = object))
+        object <- CreateSeuratObject(counts = as.sparse(x = object), min.cells = 1, min.features = 1)
       } else if (inherits(x = object, what = 'Seurat')) {
         if (!'RNA' %in% Assays(object = object)) {
           stop("No RNA assay provided", call. = FALSE)
         } else if (Seurat:::IsMatrixEmpty(x = GetAssayData(object = object, slot = 'counts', assay = 'RNA'))) {
           stop("No RNA counts matrix present", call. = FALSE)
         }
-        DefaultAssay(object = object) <- "RNA"
-        object <- DietSeurat(
-          object = object,
-          assays = "RNA"
+        object <- CreateSeuratObject(
+          counts = GetAssayData(object = object[["RNA"]], slot = "counts"),
+          min.cells = 1,
+          min.features = 1,
+          meta.data = object[[]]
         )
       } else {
         stop("The RDS file must be a Seurat object", call. = FALSE)
@@ -115,7 +116,12 @@ LoadFileInput <- function(path) {
         graphs = FALSE,
         images = FALSE
       )
-      object
+      object <- CreateSeuratObject(
+        counts = GetAssayData(object = object[["RNA"]], slot = "counts"),
+        min.cells = 1,
+        min.features = 1,
+        meta.data = object[[]]
+      )
     },
     stop("Unknown file type: ", type, call. = FALSE)
   ))


### PR DESCRIPTION
Adds `min.cells =1` and `min.features = 1` when loading in query data to prevent downstream errors from having cells with zero counts or features with no counts.

