### PR TITLE
Fix issue when query and ref cell names overlap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Azimuth
 Type: Package
 Title: A Shiny App Demonstrating a Query-Reference Mapping Algorithm for Single-Cell Data
-Version: 0.4.1
+Version: 0.4.1.9001
 Date: 2021-06-01
 Authors@R: c(
   person(given = 'Andrew', family = 'Butler', email = 'abutler@nygenome.org', role = 'aut', comment = c(ORCID = '0000-0003-3608-0463')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changes
+- Bug fix when query cell name(s) overlap with reference names
+
 # Azimuth 0.4.1 (2021-06-01)
 
 ## Added

--- a/R/server.R
+++ b/R/server.R
@@ -84,7 +84,8 @@ AzimuthServer <- function(input, output, session) {
     merged = NULL,
     metadata.discrete = NULL,
     metadata.notransfer = NULL,
-    disable = FALSE
+    disable = FALSE,
+    query.names = character()
   )
   react.env <- reactiveValues(
     no = FALSE,
@@ -448,6 +449,13 @@ AzimuthServer <- function(input, output, session) {
                 }
                 app.env$object$query <- 'query'
                 Idents(object = app.env$object) <- 'query'
+                # check that no names overlap with reference
+                query.cell.names <- paste0("query", 1:ncol(x = app.env$object))
+                while (any(query.cell.names %in% Cells(x = refs$map))) {
+                  query.cell.names <- paste0(query.cell.names, "x")
+                }
+                app.env$query.names <- Cells(x = app.env$object)
+                app.env$object <- RenameCells(object = app.env$object, new.names = query.cell.names)
 
                 app.env$default.assay <- DefaultAssay(object = app.env$object)
                 new.mt <- any(grepl(
@@ -1311,6 +1319,7 @@ AzimuthServer <- function(input, output, session) {
             )
           )
         })
+        app.env$object <- RenameCells(object = app.env$object, new.names = app.env$query.names)
         react.env$progress$close()
         enable(id = 'file')
         ToggleDemos(action = "enable", demos = demos)


### PR DESCRIPTION
Issue in some renaming functions if query and reference cell names overlap. 