### PR TITLE
homolog.table as reference in RunAzimuth

### DIFF
--- a/R/azimuth.R
+++ b/R/azimuth.R
@@ -31,7 +31,8 @@ RunAzimuth.Seurat <- function(
   assay = NULL,
   k.weight = 50,
   n.trees = 20,
-  mapping.score.k = 100, 
+  mapping.score.k = 100,
+  homolog.table = 'https://seurat.nygenome.org/azimuth/references/homologs.rds',
   ...
 ) {
   CheckDots(...)
@@ -100,7 +101,7 @@ RunAzimuth.Seurat <- function(
     query <- ConvertGeneNames(
       object = query,
       reference.names = rownames(x = reference),
-      homolog.table = 'https://seurat.nygenome.org/azimuth/references/homologs.rds'
+      homolog.table = homolog.table
     )
     
     # Calculate nCount_RNA and nFeature_RNA if the query does not


### PR DESCRIPTION
Hello,

`RunAzimuth` currently uses a hardcoded reference of the `homolog.table` in `ConvertGeneNames` which relies on an internet link and assumes an internet connection is available. 
https://github.com/satijalab/azimuth/blob/243ee5db80fcbffa3452c944254a325a3da2ef9e/R/azimuth.R#L103

Allowing to specify the location of the `homolog.table` in `RunAzimuth` would allow an offline execution of the function and improve flexibility. 

Please let me know your opinion. Thank you in advance!

Best,